### PR TITLE
make ErrorWindow internationalizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Official releases of this add-on are available through Vaadin Directory.
 
 ## Building and running demo
 
-git clone https://github.com/FlowingCode/error-window-addon
-mvn clean install
-cd demo
-mvn jetty:run
+- git clone https://github.com/FlowingCode/error-window-addon
+- mvn clean install
+- cd demo
+- mvn jetty:run
 
 To see the demo, navigate to http://localhost:8080/
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
             <id>Vaadin Directory</id>
             <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
+        <repository>
+                <id>FlowingCode Releases</id>
+                <url>https://maven.flowingcode.com/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -118,7 +122,7 @@
 		<dependency>
 			<groupId>com.flowingcode.vaadin.addons.demo</groupId>
 			<artifactId>commons-demo</artifactId>
-			<version>2.1.0-SNAPSHOT</version>
+			<version>3.0.0</version>
 			<scope>test</scope>
 		</dependency>
     </dependencies>

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/DefaultErrorWindowFactory.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/DefaultErrorWindowFactory.java
@@ -23,7 +23,7 @@ public class DefaultErrorWindowFactory implements ErrorWindowFactory {
 
 	@Override
 	public void showError(ErrorDetails details) {
-		ErrorWindow w = new ErrorWindow(details, isProductionMode());
+		ErrorWindow w = new ErrorWindow(details);
 		w.open();
 	}
 

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorManager.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorManager.java
@@ -39,5 +39,9 @@ public final class ErrorManager {
 	public static void setErrorWindowFactory(ErrorWindowFactory errorWindowFactory) {
 		ErrorManager.errorWindowFactory = errorWindowFactory;
 	}
+	
+	public static ErrorWindowFactory getErrorWindowFactory() {
+		return errorWindowFactory;
+	}
 
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
@@ -63,11 +63,11 @@ public class ErrorWindow extends Dialog {
 	private boolean productionMode;
 
 	public ErrorWindow(final Throwable cause) {
-		this(cause, null, false);
+		this(cause, null, isProductionMode());
 	}
 
 	public ErrorWindow(final Throwable cause, final String errorMessage) {
-		this(cause, errorMessage, false);
+		this(cause, errorMessage, isProductionMode());
 	}
 
 	public ErrorWindow(final Throwable cause, final String errorMessage, boolean productionMode) {
@@ -80,8 +80,12 @@ public class ErrorWindow extends Dialog {
 		initWindow();
 	}
 	
-	public ErrorWindow(ErrorDetails errorDetails, boolean productionMode) {
-		this(errorDetails.getThrowable(),errorDetails.getCause(),productionMode);
+	public ErrorWindow(ErrorDetails errorDetails) {
+		this(errorDetails.getThrowable(), errorDetails.getCause());
+	}
+
+	private static boolean isProductionMode() {
+		return ("true".equals(System.getProperty("productionMode")));
 	}
 
 	private void initWindow() {

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
@@ -46,134 +46,134 @@ import com.vaadin.flow.component.textfield.TextArea;
 @SuppressWarnings("serial")
 public class ErrorWindow extends Dialog {
 
-    private static final Logger logger = LoggerFactory.getLogger(ErrorWindow.class);
+	private static final Logger logger = LoggerFactory.getLogger(ErrorWindow.class);
 
-    private static final String DEFAULT_CAPTION = "<h3 style='margin-top:0px;text-align:center'>An error has occurred</h3>";
+	private static final String DEFAULT_CAPTION = "<h3 style='margin-top:0px;text-align:center'>An error has occurred</h3>";
 
-    private static final String DEFAULT_ERROR_LABEL_MESSAGE = "Please contact the system administrator for more information.";
+	private static final String DEFAULT_ERROR_LABEL_MESSAGE = "Please contact the system administrator for more information.";
 
-    private VerticalLayout exceptionTraceLayout;
+	private VerticalLayout exceptionTraceLayout;
 
-    private final Throwable cause;
+	private final Throwable cause;
 
-    private final String errorMessage;
+	private final String errorMessage;
 
-    private final String uuid;
+	private final String uuid;
 
 	private boolean productionMode;
 
-    public ErrorWindow(final Throwable cause) {
-        this(cause, null, false);
-    }
+	public ErrorWindow(final Throwable cause) {
+		this(cause, null, false);
+	}
 
-    public ErrorWindow(final Throwable cause, final String errorMessage) {
-        this(cause, errorMessage, false);
-    }
+	public ErrorWindow(final Throwable cause, final String errorMessage) {
+		this(cause, errorMessage, false);
+	}
 
-    public ErrorWindow(final Throwable cause, final String errorMessage, boolean productionMode) {
-        super();
+	public ErrorWindow(final Throwable cause, final String errorMessage, boolean productionMode) {
+		super();
 
-        uuid = UUID.randomUUID().toString();
-        this.cause = cause;
-        this.errorMessage = errorMessage;
-        this.productionMode = productionMode;
-        initWindow();
-    }
-    
-    public ErrorWindow(ErrorDetails errorDetails, boolean productionMode) {
-    	this(errorDetails.getThrowable(),errorDetails.getCause(),productionMode);
-    }
+		uuid = UUID.randomUUID().toString();
+		this.cause = cause;
+		this.errorMessage = errorMessage;
+		this.productionMode = productionMode;
+		initWindow();
+	}
+	
+	public ErrorWindow(ErrorDetails errorDetails, boolean productionMode) {
+		this(errorDetails.getThrowable(),errorDetails.getCause(),productionMode);
+	}
 
-    private void initWindow() {
-    	if (logger.isErrorEnabled()) {
-            logger.error(String.format("Error occurred %s", uuid), cause);
-    	}
-        setWidth("800px");
-        setCloseOnEsc(true);
-        add(createMainLayout());
-    }
+	private void initWindow() {
+		if (logger.isErrorEnabled()) {
+			logger.error(String.format("Error occurred %s", uuid), cause);
+		}
+		setWidth("800px");
+		setCloseOnEsc(true);
+		add(createMainLayout());
+	}
 
-    /**
-     * Creates the main layout of the ErrorWindow.
-     */
-    private VerticalLayout createMainLayout() {
-        final VerticalLayout mainLayout = new VerticalLayout();
-        mainLayout.setSpacing(false);
-        mainLayout.setPadding(false);
-        mainLayout.setMargin(false);
-       
-        final Html title = new Html(DEFAULT_CAPTION);
-        title.getElement().getStyle().set("width", "100%");
-        mainLayout.add(title);
-        
-        final Html errorLabel = createErrorLabel();
-        mainLayout.add(errorLabel);
-        mainLayout.setHorizontalComponentAlignment(Alignment.START,errorLabel);
+	/**
+	 * Creates the main layout of the ErrorWindow.
+	 */
+	private VerticalLayout createMainLayout() {
+		final VerticalLayout mainLayout = new VerticalLayout();
+		mainLayout.setSpacing(false);
+		mainLayout.setPadding(false);
+		mainLayout.setMargin(false);
+	   
+		final Html title = new Html(DEFAULT_CAPTION);
+		title.getElement().getStyle().set("width", "100%");
+		mainLayout.add(title);
+		
+		final Html errorLabel = createErrorLabel();
+		mainLayout.add(errorLabel);
+		mainLayout.setHorizontalComponentAlignment(Alignment.START,errorLabel);
 
-        HorizontalLayout buttonsLayout = new HorizontalLayout();
-        buttonsLayout.setSpacing(true);
-        buttonsLayout.setPadding(false);
-        buttonsLayout.setMargin(false);
-        
-        if (!productionMode) {
-        	Button button = createDetailsButtonLayout();
-        	buttonsLayout.add(button);
-            mainLayout.add(createExceptionTraceLayout());
-        }
+		HorizontalLayout buttonsLayout = new HorizontalLayout();
+		buttonsLayout.setSpacing(true);
+		buttonsLayout.setPadding(false);
+		buttonsLayout.setMargin(false);
+		
+		if (!productionMode) {
+			Button button = createDetailsButtonLayout();
+			buttonsLayout.add(button);
+			mainLayout.add(createExceptionTraceLayout());
+		}
 
-        final Button closeButton = new Button("Close", event -> close());
-        buttonsLayout.add(closeButton);
-        mainLayout.add(buttonsLayout);
-        mainLayout.setHorizontalComponentAlignment(Alignment.END, buttonsLayout);
-        
-        return mainLayout;
-    }
+		final Button closeButton = new Button("Close", event -> close());
+		buttonsLayout.add(closeButton);
+		mainLayout.add(buttonsLayout);
+		mainLayout.setHorizontalComponentAlignment(Alignment.END, buttonsLayout);
+		
+		return mainLayout;
+	}
 
-    private Button createDetailsButtonLayout() {
-        final Button errorDetailsButton = new Button("Show error detail", event -> {
-    		boolean visible = !exceptionTraceLayout.isVisible();
-        	exceptionTraceLayout.setVisible(visible);
-        	if(visible) {
-        		event.getSource().setIcon(VaadinIcon.MINUS.create());
-        	} else {
-                event.getSource().setIcon(VaadinIcon.PLUS.create());
-        	}
-        });
-        errorDetailsButton.setIcon(VaadinIcon.PLUS.create());
-        return errorDetailsButton;
-    }
+	private Button createDetailsButtonLayout() {
+		final Button errorDetailsButton = new Button("Show error detail", event -> {
+			boolean visible = !exceptionTraceLayout.isVisible();
+			exceptionTraceLayout.setVisible(visible);
+			if(visible) {
+				event.getSource().setIcon(VaadinIcon.MINUS.create());
+			} else {
+				event.getSource().setIcon(VaadinIcon.PLUS.create());
+			}
+		});
+		errorDetailsButton.setIcon(VaadinIcon.PLUS.create());
+		return errorDetailsButton;
+	}
 
-    
-    private VerticalLayout createExceptionTraceLayout() {
-        exceptionTraceLayout = new VerticalLayout();
-        exceptionTraceLayout.setSpacing(false);
-        exceptionTraceLayout.setMargin(false);
-        exceptionTraceLayout.setPadding(false);
-        exceptionTraceLayout.add(createStackTraceArea());
-        exceptionTraceLayout.setVisible(false);
-        return exceptionTraceLayout;
-    }
+	
+	private VerticalLayout createExceptionTraceLayout() {
+		exceptionTraceLayout = new VerticalLayout();
+		exceptionTraceLayout.setSpacing(false);
+		exceptionTraceLayout.setMargin(false);
+		exceptionTraceLayout.setPadding(false);
+		exceptionTraceLayout.add(createStackTraceArea());
+		exceptionTraceLayout.setVisible(false);
+		return exceptionTraceLayout;
+	}
 
-    protected TextArea createStackTraceArea() {
-        final TextArea area = new TextArea();
-        area.setWidthFull();
-        area.setHeight("15em");
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final PrintWriter pw = new PrintWriter(baos);
-        cause.printStackTrace(pw);
-        pw.flush();
-        area.setValue(baos.toString());
-        return area;
-    }
+	protected TextArea createStackTraceArea() {
+		final TextArea area = new TextArea();
+		area.setWidthFull();
+		area.setHeight("15em");
+		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		final PrintWriter pw = new PrintWriter(baos);
+		cause.printStackTrace(pw);
+		pw.flush();
+		area.setValue(baos.toString());
+		return area;
+	}
 
-    protected Html createErrorLabel() {
-        String label = errorMessage == null ? DEFAULT_ERROR_LABEL_MESSAGE : errorMessage;
-        if (productionMode) {
-            label = label.concat(String.format("<br />Please report the following code to system administrator:<h4><p><center>%s<center/></p></h4>", uuid));
-        }
-        final Html errorLabel = new Html("<span>" + label + "</span>");
-        errorLabel.getElement().getStyle().set("width", "100%");
-        return errorLabel;
-    }
+	protected Html createErrorLabel() {
+		String label = errorMessage == null ? DEFAULT_ERROR_LABEL_MESSAGE : errorMessage;
+		if (productionMode) {
+			label = label.concat(String.format("<br />Please report the following code to system administrator:<h4><p><center>%s<center/></p></h4>", uuid));
+		}
+		final Html errorLabel = new Html("<span>" + label + "</span>");
+		errorLabel.getElement().getStyle().set("width", "100%");
+		return errorLabel;
+	}
 
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
@@ -94,6 +94,10 @@ public class ErrorWindow extends Dialog {
 		this(errorDetails, ErrorWindowI18n.createDefault());
 	}
 
+	public ErrorWindow(ErrorDetails errorDetails, boolean productionMode) {
+		this(errorDetails.getThrowable(), errorDetails.getCause(), isProductionMode(), ErrorWindowI18n.createDefault());
+	}
+	
 	public ErrorWindow(ErrorDetails errorDetails, final ErrorWindowI18n i18n) {
 		this(errorDetails.getThrowable(), errorDetails.getCause(), i18n);
 	}

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
@@ -99,7 +99,7 @@ public class ErrorWindow extends Dialog {
 	}
 
 	private static boolean isProductionMode() {
-		return ("true".equals(System.getProperty("productionMode")));
+		return ErrorManager.getErrorWindowFactory().isProductionMode();
 	}
 
 	private void initWindow() {

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
@@ -48,10 +48,6 @@ public class ErrorWindow extends Dialog {
 
 	private static final Logger logger = LoggerFactory.getLogger(ErrorWindow.class);
 
-	private static final String DEFAULT_CAPTION = "<h3 style='margin-top:0px;text-align:center'>An error has occurred</h3>";
-
-	private static final String DEFAULT_ERROR_LABEL_MESSAGE = "Please contact the system administrator for more information.";
-
 	private VerticalLayout exceptionTraceLayout;
 
 	private final Throwable cause;
@@ -62,26 +58,44 @@ public class ErrorWindow extends Dialog {
 
 	private boolean productionMode;
 
+	private ErrorWindowI18n i18n;
+
 	public ErrorWindow(final Throwable cause) {
-		this(cause, null, isProductionMode());
+		this(cause, null, isProductionMode(), ErrorWindowI18n.createDefault());
+	}
+
+	public ErrorWindow(final Throwable cause, final ErrorWindowI18n i18n) {
+		this(cause, null, isProductionMode(), i18n);
 	}
 
 	public ErrorWindow(final Throwable cause, final String errorMessage) {
-		this(cause, errorMessage, isProductionMode());
+		this(cause, errorMessage, isProductionMode(), ErrorWindowI18n.createDefault());
+	}
+
+	public ErrorWindow(final Throwable cause, final String errorMessage, final ErrorWindowI18n i18n) {
+		this(cause, errorMessage, isProductionMode(), i18n);
 	}
 
 	public ErrorWindow(final Throwable cause, final String errorMessage, boolean productionMode) {
+		this(cause, errorMessage, productionMode, ErrorWindowI18n.createDefault());
+	}
+	public ErrorWindow(final Throwable cause, final String errorMessage, boolean productionMode, final ErrorWindowI18n i18n) {
 		super();
 
 		uuid = UUID.randomUUID().toString();
 		this.cause = cause;
 		this.errorMessage = errorMessage;
 		this.productionMode = productionMode;
+		this.i18n = i18n;
 		initWindow();
 	}
 	
 	public ErrorWindow(ErrorDetails errorDetails) {
-		this(errorDetails.getThrowable(), errorDetails.getCause());
+		this(errorDetails, ErrorWindowI18n.createDefault());
+	}
+
+	public ErrorWindow(ErrorDetails errorDetails, final ErrorWindowI18n i18n) {
+		this(errorDetails.getThrowable(), errorDetails.getCause(), i18n);
 	}
 
 	private static boolean isProductionMode() {
@@ -105,8 +119,8 @@ public class ErrorWindow extends Dialog {
 		mainLayout.setSpacing(false);
 		mainLayout.setPadding(false);
 		mainLayout.setMargin(false);
-	   
-		final Html title = new Html(DEFAULT_CAPTION);
+
+		final Html title = new Html(String.format("<h3 style='margin-top:0px;text-align:center'>%s</h3>", i18n.getCaption()));
 		title.getElement().getStyle().set("width", "100%");
 		mainLayout.add(title);
 		
@@ -125,7 +139,7 @@ public class ErrorWindow extends Dialog {
 			mainLayout.add(createExceptionTraceLayout());
 		}
 
-		final Button closeButton = new Button("Close", event -> close());
+		final Button closeButton = new Button(i18n.getClose(), event -> close());
 		buttonsLayout.add(closeButton);
 		mainLayout.add(buttonsLayout);
 		mainLayout.setHorizontalComponentAlignment(Alignment.END, buttonsLayout);
@@ -134,7 +148,7 @@ public class ErrorWindow extends Dialog {
 	}
 
 	private Button createDetailsButtonLayout() {
-		final Button errorDetailsButton = new Button("Show error detail", event -> {
+		final Button errorDetailsButton = new Button(i18n.getDetails(), event -> {
 			boolean visible = !exceptionTraceLayout.isVisible();
 			exceptionTraceLayout.setVisible(visible);
 			if(visible) {
@@ -171,9 +185,9 @@ public class ErrorWindow extends Dialog {
 	}
 
 	protected Html createErrorLabel() {
-		String label = errorMessage == null ? DEFAULT_ERROR_LABEL_MESSAGE : errorMessage;
+		String label = errorMessage == null ? i18n.getDefaultErrorMessage() : errorMessage;
 		if (productionMode) {
-			label = label.concat(String.format("<br />Please report the following code to system administrator:<h4><p><center>%s<center/></p></h4>", uuid));
+			label = label.concat(String.format("<br />%s<h4><p><center>%s<center/></p></h4>", i18n.getInstructions(), uuid));
 		}
 		final Html errorLabel = new Html("<span>" + label + "</span>");
 		errorLabel.getElement().getStyle().set("width", "100%");

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindowFactory.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindowFactory.java
@@ -22,5 +22,9 @@ package com.flowingcode.vaadin.addons.errorwindow;
 public interface ErrorWindowFactory {
 
 	void showError(ErrorDetails details);
+	
+	default boolean isProductionMode() {
+		return ("true".equals(System.getProperty("productionMode")));
+	}
 
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindowFactory.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindowFactory.java
@@ -22,9 +22,5 @@ package com.flowingcode.vaadin.addons.errorwindow;
 public interface ErrorWindowFactory {
 
 	void showError(ErrorDetails details);
-	
-	default boolean isProductionMode() {
-		return ("true".equals(System.getProperty("productionMode")));
-	}
 
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindowI18n.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindowI18n.java
@@ -1,0 +1,122 @@
+/*-
+ * #%L
+ * Error Window Add-on Project
+ * %%
+ * Copyright (C) 2018 - 2020 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.errorwindow;
+
+/**
+ * Internationalization object for customizing the component UI texts.
+ * An instance with the default messages can be obtained using {@link ErrorWindowI18n#createDefault()}
+ *
+ * @author michael.knigge@gmx.de
+ *
+ */
+public class ErrorWindowI18n {
+
+	private String caption;
+	private String instructions;
+	private String close;
+	private String details;
+	private String defaultErrorMessage;
+
+	private ErrorWindowI18n() {
+		this.caption = "An error has occurred";
+		this.instructions = "Please report the following code to your system administrator";
+		this.close = "Close";
+		this.details = "Show error details";
+		this.defaultErrorMessage = "Please contact the system administrator for more information.";
+	}
+
+	/**
+	 * @return a new instance with the default messages
+	 */
+	public static ErrorWindowI18n createDefault() {
+		return new ErrorWindowI18n();
+	}
+
+	/**
+	 * Sets the caption of the error window.
+	 */
+	public void setCaption(final String caption) {
+		this.caption = caption;
+	}
+
+	/**
+	 * @return returns the caption of the error window.
+	 */
+	public String getCaption() {
+		return this.caption;
+	}
+
+	/**
+	 * Sets the instructions for the user if the UUID is displayed in production mode.
+	 */
+	public void setInstructions(final String instructions) {
+		this.instructions = instructions;
+	}
+
+	/**
+	 * @return returns the instructions for the user if the UUID is displayed in production mode.
+	 */
+	public String getInstructions() {
+		return this.instructions;
+	}
+
+	/**
+	 * Sets the text of the "Close"-Button.
+	 */
+	public void setClose(final String close) {
+		this.close = close;
+	}
+
+	/**
+	 * @return returns the text of the "Close"-Button.
+	 */
+	public String getClose() {
+		return this.close;
+	}
+
+	/**
+	 * Sets the text of the "Details"-Button.
+	 */
+	public void setDetails(final String details) {
+		this.details = details;
+	}
+
+	/**
+	 * @return returns the text of the "Details"-Button.
+	 */
+	public String getDetails() {
+		return this.details;
+	}
+
+	/**
+	 * Sets the default error message shown if the message passed to the error window is <code>null</code>.
+	 */
+	public void setDefaultErrorMessage(final String defaultErrorMessage) {
+		this.defaultErrorMessage = defaultErrorMessage;
+	}
+
+	/**
+	 * @return returns the default error message shown if the message passed to the error window is <code>null</code>.
+	 */
+	public String getDefaultErrorMessage() {
+		return this.defaultErrorMessage;
+	}
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/errorwindow/ErrorwindowDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/errorwindow/ErrorwindowDemo.java
@@ -49,6 +49,21 @@ public class ErrorwindowDemo extends VerticalLayout {
 			}
 		});
 
+		Button throwErrorWithCustomMessageAndCustomTexts = new Button("Throw Error with custom message (custom labels)", ev -> {
+			try {
+				Integer.parseInt("asdf");
+			} catch (NumberFormatException e) {
+				ErrorWindowI18n i18n = ErrorWindowI18n.createDefault();
+				i18n.setCaption("Uh oh... that's embarrassing");
+				i18n.setInstructions("Please pass this unique error identifier to your administrator");
+				i18n.setClose("Ok");
+				i18n.setDetails("Show me technical details");
+				i18n.setDefaultErrorMessage("Something really strange happened");
+				ErrorWindow w = new ErrorWindow(e, "CUSTOM ERROR MESSAGE", i18n);
+				w.open();
+			}
+		});
+
 		Checkbox productionModeCb = new Checkbox("Production Mode");
 		productionModeCb.addValueChangeListener(e -> {
 			System.setProperty("productionMode", "" + productionModeCb.getValue().toString());
@@ -56,7 +71,7 @@ public class ErrorwindowDemo extends VerticalLayout {
 		});
 
 		setSizeFull();
-		add(productionModeCb, errorButton, throwErrorWithoutErrorHandler, throwErrorWithCustomMessage);
+		add(productionModeCb, errorButton, throwErrorWithoutErrorHandler, throwErrorWithCustomMessageAndCustomTexts, throwErrorWithCustomMessage);
 	}
 
 }


### PR DESCRIPTION
This pull request is for https://github.com/FlowingCode/ErrorWindowAddon/issues/16

This PR fixes minor stuff (see README.md), changes the behaviour a little bit and adds the possibility to change all the lables (so the user can use custom texts, i. e. for i18n.

The changed behaviour also fixes a little bug in the demo application. The demo application did exactly the same if the user pressed the last button "Throw Error with custom message" - no matter if in "production mode" or not. My little change lets the ErrorWindow decide if we are in production mode or not. This conforms to the JavaDoc (see "When in production mode it shows a code to report"). That was not the truth because (at least) two constructors just passed "false" for productionMode...

Now the code does what the JavaDoc says...

I would be happy if this PR get's accepted and a new release is published....