### PR TITLE
chore: correct inception year

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<maven>3</maven>
 	</prerequisites>
 	
-	<inceptionYear>2018</inceptionYear>
+	<inceptionYear>2017</inceptionYear>
 	<organization>
 		<name>Flowing Code</name>
 		<url>https://www.flowingcode.com</url>

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/DefaultErrorWindowFactory.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/DefaultErrorWindowFactory.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorDetails.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorDetails.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorManager.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorManager.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindowFactory.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindowFactory.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindowI18n.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindowI18n.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/VaadinServiceInitListenerImpl.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/VaadinServiceInitListenerImpl.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/errorwindow/DemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/errorwindow/DemoView.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/errorwindow/ErrorwindowDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/errorwindow/ErrorwindowDemo.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/errorwindow/ErrorwindowDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/errorwindow/ErrorwindowDemoView.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/errorwindow/test/LayoutTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/errorwindow/test/LayoutTest.java
@@ -1,8 +1,8 @@
 /*-
  * #%L
- * Error Window Add-on Project
+ * Error Window Add-on
  * %%
- * Copyright (C) 2018 - 2020 Flowing Code
+ * Copyright (C) 2017 - 2020 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The initial commit was in 2017 (342ac06514aa55db0762dd99d7c3daf920964c71), but the inception year was set as 2018 (4334fca3911faecb7e948aa239daafe9127521d5).