### PR TITLE
chore: ignore ThrowInConstructorView

### DIFF
--- a/src/test/java/com/flowingcode/vaadin/addons/errorwindow/ThrowInConstructorView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/errorwindow/ThrowInConstructorView.java
@@ -21,7 +21,9 @@ package com.flowingcode.vaadin.addons.errorwindow;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
+import org.junit.Ignore;
 
+@Ignore
 @Route("error-window/throw")
 public class ThrowInConstructorView extends Div {
 


### PR DESCRIPTION
This view has to be excluded from tests https://github.com/FlowingCode/AddonsDemoV14/blob/3d77f51e3d4c8c5a22da330c1252770b89a8e280/src/test/java/com/flowingcode/vaadin/addons/LayoutTest.java#L66-L69