### PR TITLE
ci: add servlet 6 dependency to Vaadin 24 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,6 +362,14 @@
 					<url>https://maven.vaadin.com/vaadin-prereleases</url>
 				</pluginRepository>
 			</pluginRepositories>
+			<dependencies>
+				<dependency>
+					<groupId>jakarta.servlet</groupId>
+					<artifactId>jakarta.servlet-api</artifactId>
+					<version>6.0.0</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
 		</profile>		
 		
 	</profiles>


### PR DESCRIPTION
Fix issue when compiling with the `v24` profile

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project error-window-vaadin: Compilation failure
[ERROR] /J:/fc/tmp/ErrorWindowAddon/src/main/java/com/flowingcode/vaadin/addons/errorwindow/VaadinServiceInitListenerImpl.java:[42,54] cannot access jakarta.servlet.http.HttpSessionBindingListener
[ERROR]   class file for jakarta.servlet.http.HttpSessionBindingListener not found
```