### PR TITLE
feat: add error event observer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 		<dependency>
 			<groupId>com.flowingcode.vaadin.addons.demo</groupId>
 			<artifactId>commons-demo</artifactId>
-			<version>3.6.0</version>
+			<version>3.7.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.flowingcode.vaadin.addons</groupId>
 	<artifactId>error-window-vaadin</artifactId>
-	<version>3.6.1-SNAPSHOT</version>
+	<version>3.7.0-SNAPSHOT</version>
 	<name>Error Window Add-on</name>
 	<description>Error handler that displays a dialog with exception information</description>
 	<url>https://www.flowingcode.com/en/open-source/</url>

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorEvent.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorEvent.java
@@ -17,25 +17,36 @@
  * limitations under the License.
  * #L%
  */
-
-
 package com.flowingcode.vaadin.addons.errorwindow;
 
-import com.flowingcode.vaadin.addons.DemoLayout;
-import com.flowingcode.vaadin.addons.GithubLink;
-import com.flowingcode.vaadin.addons.demo.TabbedDemo;
-import com.vaadin.flow.router.ParentLayout;
-import com.vaadin.flow.router.Route;
+import com.vaadin.flow.component.UI;
+import java.util.EventObject;
 
-@SuppressWarnings("serial")
-@ParentLayout(DemoLayout.class)
-@Route("error-window")
-@GithubLink("https://github.com/FlowingCode/ErrorWindowAddon")
-public class ErrorwindowDemoView extends TabbedDemo {
+/**
+ * Event object with a exception trace.
+ */
+public class ErrorEvent extends EventObject {
 
-  public ErrorwindowDemoView() {
-    addDemo(ErrorwindowDemo.class);
-    addDemo(ErrorEventObserverDemo.class);
-    setSizeFull();
+  private Throwable throwable;
+
+  private boolean preventDefault;
+
+  public ErrorEvent(UI ui, Throwable throwable) {
+    super(ui);
+    this.throwable = throwable;
   }
+
+  public Throwable getThrowable() {
+    return throwable;
+  }
+
+  /** Prevents the default processing by {@link ErrorWindowFactory}. */
+  public void preventDefault() {
+    preventDefault = true;
+  }
+
+  public boolean isPreventDefault() {
+    return preventDefault;
+  }
+
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorEventObserver.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorEventObserver.java
@@ -17,25 +17,22 @@
  * limitations under the License.
  * #L%
  */
-
-
 package com.flowingcode.vaadin.addons.errorwindow;
 
-import com.flowingcode.vaadin.addons.DemoLayout;
-import com.flowingcode.vaadin.addons.GithubLink;
-import com.flowingcode.vaadin.addons.demo.TabbedDemo;
-import com.vaadin.flow.router.ParentLayout;
-import com.vaadin.flow.router.Route;
+import java.io.Serializable;
 
-@SuppressWarnings("serial")
-@ParentLayout(DemoLayout.class)
-@Route("error-window")
-@GithubLink("https://github.com/FlowingCode/ErrorWindowAddon")
-public class ErrorwindowDemoView extends TabbedDemo {
+/**
+ * Any {@code com.vaadin.ui.Component} implementing this interface will be informed when
+ * {@link ErrorManager} handles an exception.
+ */
+@FunctionalInterface
+public interface ErrorEventObserver extends Serializable {
 
-  public ErrorwindowDemoView() {
-    addDemo(ErrorwindowDemo.class);
-    addDemo(ErrorEventObserverDemo.class);
-    setSizeFull();
-  }
+  /**
+   * Notifies when {@link ErrorManager} handles an exception.
+   *
+   * @param event error event with exception details
+   */
+  void onError(ErrorEvent event);
+
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorEventWindowFactory.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorEventWindowFactory.java
@@ -1,0 +1,72 @@
+/*-
+ * #%L
+ * Error Window Add-on
+ * %%
+ * Copyright (C) 2017 - 2023 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.errorwindow;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.EventUtil;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+final class ErrorEventWindowFactory implements ErrorWindowFactory {
+
+  private final ErrorWindowFactory delegate;
+
+  private ErrorEventWindowFactory(ErrorWindowFactory delegate) {
+    this.delegate = Objects.requireNonNull(delegate);
+  }
+
+  public static ErrorWindowFactory newInstance(ErrorWindowFactory delegate) {
+    return new ErrorEventWindowFactory(delegate);
+  }
+
+  @Override
+  public void showError(ErrorDetails details) {
+    UI ui = UI.getCurrent();
+    ErrorEvent event = new ErrorEvent(ui, details.getThrowable());
+    collectErrorEventObservers(ui.getElement()).forEach(observer -> observer.onError(event));
+    if (!event.isPreventDefault()) {
+      delegate.showError(details);
+    }
+  }
+
+  @Override
+  public boolean isProductionMode() {
+    return delegate.isProductionMode();
+  }
+
+  public static List<ErrorEventObserver> collectErrorEventObservers(Element element) {
+    return EventUtil
+        .getImplementingComponents(flattenDescendants(element), ErrorEventObserver.class)
+        .collect(Collectors.toList());
+  }
+
+  // see EventUtil.flattenDescendants
+  private static Stream<Element> flattenDescendants(Element element) {
+    Collection<Element> descendants = new ArrayList<>();
+    EventUtil.inspectHierarchy(element, descendants, item -> true);
+    return descendants.stream();
+  }
+
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorManager.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorManager.java
@@ -90,6 +90,7 @@ public final class ErrorManager {
    */
   public static ErrorWindowFactory getErrorWindowFactory(Class<?> clazz) {
     return Optional.ofNullable(factories.get(clazz))
+        .map(ErrorEventWindowFactory::newInstance)
         .orElseGet(() -> getErrorWindowFactory(clazz.getSuperclass()));
   }
 

--- a/src/test/java/com/flowingcode/vaadin/addons/errorwindow/ErrorEventObserverDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/errorwindow/ErrorEventObserverDemo.java
@@ -1,0 +1,82 @@
+/*-
+ * #%L
+ * Error Window Add-on
+ * %%
+ * Copyright (C) 2017 - 2023 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+package com.flowingcode.vaadin.addons.errorwindow;
+
+import com.flowingcode.vaadin.addons.demo.DemoSource;
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.upload.Upload;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+@DemoSource
+@PageTitle("Error Event")
+@Route(value = "error-window/error-event", layout = ErrorwindowDemoView.class)
+@SuppressWarnings("serial")
+public class ErrorEventObserverDemo extends VerticalLayout implements ErrorEventObserver {
+
+  private VerticalLayout target = new VerticalLayout();
+
+  @Override
+  public void onError(ErrorEvent event) {
+    String str = "We handled a " + event.getThrowable().getClass().getName();
+    target.add(new Div(new Text(str)));
+    event.preventDefault();
+  }
+
+  public ErrorEventObserverDemo() {
+    ErrorWindowI18n errorWindowI18n = ErrorWindowI18n.create(this::getTranslation);
+    ErrorManager.setErrorWindowFactory(new I18nErrorWindowFactory(errorWindowI18n));
+
+    Button errorButton =
+        new Button(
+            "Throw Error",
+            event -> {
+              throw new RuntimeException("Uh oh!");
+            });
+
+    Button throwErrorWithoutErrorHandler =
+        new Button(
+            "Throw Error without an error handler",
+            ev -> {
+              try {
+                throw new RuntimeException("Uh oh!");
+              } catch (RuntimeException e) {
+                ErrorManager.showError(e);
+              }
+            });
+
+    Upload upload = new Upload(new NullMemoryBuffer());
+    upload.addSucceededListener(ev -> {
+      throw new UnsupportedOperationException("File upload is not allowed");
+    });
+
+    setSizeFull();
+    add(errorButton, throwErrorWithoutErrorHandler, upload);
+
+    add(target);
+    target.add(new Text("Errors will be appended here:"));
+  }
+
+}


### PR DESCRIPTION
Implement a mechanism that allows handling errors in the layout.

![image](https://github.com/FlowingCode/ErrorWindowAddon/assets/11554739/79c9d15e-f30f-4fea-83cb-cbcdf9569872)
