### PR TITLE
fix!: interpret exception message as plain text instead of HTML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.flowingcode.vaadin.addons</groupId>
 	<artifactId>error-window-vaadin</artifactId>
-	<version>3.7.1-SNAPSHOT</version>
+	<version>4.0.0-SNAPSHOT</version>
 	<name>Error Window Add-on</name>
 	<description>Error handler that displays a dialog with exception information</description>
 	<url>https://www.flowingcode.com/en/open-source/</url>

--- a/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/errorwindow/ErrorWindow.java
@@ -23,12 +23,14 @@ package com.flowingcode.vaadin.addons.errorwindow;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Html;
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -216,7 +218,7 @@ public class ErrorWindow extends Dialog {
     title.getElement().getStyle().set("width", "100%");
     mainLayout.add(title);
 
-    final Html errorLabel = createErrorLabel();
+    Component errorLabel = createErrorLabel();
     mainLayout.add(errorLabel);
     mainLayout.setHorizontalComponentAlignment(Alignment.START, errorLabel);
 
@@ -300,18 +302,21 @@ public class ErrorWindow extends Dialog {
     pw.flush();
     return baos.toString();
   }
-  
-  protected Html createErrorLabel() {
-    String label = errorMessage == null ? i18n.getDefaultErrorMessage() : errorMessage;
+
+  protected Component createErrorLabel() {
+    Div errorLabel = new Div();
+    errorLabel.setClassName("errorlabel");
+
     if (productionMode) {
-      label =
-          label.concat(
-              String.format(
-                  "<br />%s<br /><span class='uuid'>%s</span>",
-                  i18n.getInstructions(), uuid));
+      Div instructions = new Div(new Text(i18n.getInstructions()));
+      Span uuidSpan = new Span(uuid);
+      uuidSpan.setClassName("uuid");
+      errorLabel.add(instructions, uuidSpan);
+    } else {
+      String label = errorMessage == null ? i18n.getDefaultErrorMessage() : errorMessage;
+      errorLabel.setText(label);
     }
-    final Html errorLabel = new Html("<span>" + label + "</span>");
-    errorLabel.getElement().getClassList().add("errorlabel");
+
     return errorLabel;
   }
 }


### PR DESCRIPTION
This is a breaking change:

- Compatibility with Existing Code: If the ErrorWindow component is widely used in an application, other parts of the application may rely on the current behavior, which allows HTML-formatted error messages. Changing this behavior could break existing code that expects HTML-formatted messages.
- User Expectations: Users of the application may expect error messages to be displayed in a specific format, such as with HTML formatting. Changing this behavior could result in unexpected changes in how errors are presented to users.
- Security Implications: Allowing HTML formatting in error messages can be risky, as it opens up the possibility of script injection attacks, where malicious code can be injected into error messages. While this is a security concern, changing the behavior to interpret messages in a text-only format could break applications that rely on legitimate HTML formatting for error messages.

Close #74 